### PR TITLE
Custom prompt

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -54,6 +54,23 @@ custom_checks:
     severity: "warning"
     note: "This is a heuristic — review manually."
 
+# Custom AI prompts manifest (file-driven approach)
+custom_prompts:
+  - id: "impact-analysis"
+    name: "PR Impact Analysis"
+    file: ".coderabbit/prompts/pr-impact-analysis.txt"
+    description: "Estimate impacted modules, suggested test areas, and potential breakage risk for C++/Yocto PRs"
+    triggers:
+      - on_pr_open
+      - on_command     # allows manual invocation via PR comment
+    file_patterns:
+      - "modules/**"
+      - "**/*.cpp"
+      - "**/*.h"
+    run_as: "assistant"   # informational only; instructs the agent role
+    required_permissions:
+      - "read:repo"       # doc only — ensure the bot has permission to read files
+
 # Labels / actions mapping
 actions:
   - on: "error"        # for custom_checks severity=error

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,72 @@
+# .coderabbit.yaml - Custom test configuration for evaluation
+profile: "assertive"
+
+# Basic inclusion/exclusion
+paths:
+  include:
+    - "modules/**"
+    - "samples/**"
+  exclude:
+    - "3rdparty/**"
+    - "build/**"
+
+# Tools to enable
+tools:
+  cppcheck:
+    enabled: true
+    args: ["--enable=warning,performance,portability"]
+  clang_tidy:
+    enabled: true
+    # If you have compile_commands.json, point to it
+    compile_commands_path: "build/compile_commands.json"
+
+# Global thresholds
+thresholds:
+  docstring_coverage: 0.80   # 80% minimum docstring coverage (C++ doc comments)
+  max_pr_files_changed: 200  # warn if >200 files changed
+  max_cyclomatic_complexity: 30
+
+# Custom regex checks (simple patterns to test custom rule capability)
+custom_checks:
+  - id: "no-todo-committed"
+    description: "Disallow 'TODO' comments in PRs"
+    pattern: "(TODO|FIXME)"
+    file_patterns:
+      - "**/*.cpp"
+      - "**/*.h"
+    severity: "warning"
+    auto_fix: false
+
+  - id: "require-changelog"
+    description: "Require CHANGELOG entry when public API headers changed"
+    pattern: "^.*$"  # any change (we'll scope by file_patterns)
+    file_patterns:
+      - "modules/**/include/**.h"
+    severity: "error"
+    condition: "if_changed"   # run when matched files changed
+    requires_file: "CHANGELOG.md"   # require presence of changelog update in PR
+
+  - id: "api-break-detect"
+    description: "Detect potential public API signature changes (simple regex)"
+    pattern: "(\\bint\\b|\\bvoid\\b|\\bstd::string\\b)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\s*\\([^;{]*\\)\\s*;"
+    file_patterns:
+      - "modules/**/include/**.h"
+    severity: "warning"
+    note: "This is a heuristic — review manually."
+
+# Labels / actions mapping
+actions:
+  - on: "error"        # for custom_checks severity=error
+    add_label: "blocked/api-change"
+    comment: "🚫 This PR changes public headers — please add a CHANGELOG.md entry explaining the API change."
+  - on: "warning"
+    add_label: "needs-review"
+    comment: "⚠️ CodeRabbit detected potential issues - please review the warnings"
+
+# PR comment templates (used for auto-summary)
+comment_templates:
+  summary: |
+    CodeRabbit automated review summary:
+    - Docstring coverage: {{docstring_coverage}} (threshold: {{thresholds.docstring_coverage}})
+    - Files changed: {{pr.files_changed}}
+    - Issues found: {{issue_count}}

--- a/.coderabbit/prompts/pr-impact-analysis.txt
+++ b/.coderabbit/prompts/pr-impact-analysis.txt
@@ -1,0 +1,20 @@
+SYSTEM:
+You are a precise code review agent configured for a large C++ / Yocto project (OpenCV-like). 
+When invoked on a pull request (PR), do the following:
+
+1) Summarize the PR in 2-3 bullet points (what files changed, main intention).
+2) List **affected modules/subsystems** (map changed files → module names).
+3) For each affected module, estimate the **risk** as Low / Medium / High and explain why (use: file churn, header changes, public API changes, changes in include headers, build flags).
+4) Produce a short **test checklist** (concrete tests to run locally in Yocto/devshell or unit tests).
+5) Detect likely **feature impacts** (user-facing endpoints, APIs, or behavior) and map them to file paths.
+6) If public headers (`modules/**/include/**/*.h` or `modules/**/include/**/*.hpp`) are changed, explicitly call out potential API breakage and recommend adding/patching `CHANGELOG.md` with the suggested changelog bullet.
+7) Provide an **actionable suggestion** (one-sentence) to reduce risk (e.g., "add unit tests for X", "pin dependency Y", "write integration test for module Z").
+8) Keep output compact (max 12 bullet points). Use code references (filename:line if available).
+
+CONSTRAINTS:
+- Do NOT invent runtime behavior not present in code diffs.
+- Mark any uncertain inference with `[?]` and a brief reason.
+- Do not include sensitive keys or environment details.
+
+INVOKE:
+- Run this only for PRs that include changes matching the file_patterns in the manifest.

--- a/.coderabbit/prompts/pr-impact-analysis.txt
+++ b/.coderabbit/prompts/pr-impact-analysis.txt
@@ -11,6 +11,9 @@ When invoked on a pull request (PR), do the following:
 7) Provide an **actionable suggestion** (one-sentence) to reduce risk (e.g., "add unit tests for X", "pin dependency Y", "write integration test for module Z").
 8) Keep output compact (max 12 bullet points). Use code references (filename:line if available).
 
+LANGUAGE:
+ As we have a new chinese intern. For every output, translate in chinese and since they are quite new, please use simpler terms.
+
 CONSTRAINTS:
 - Do NOT invent runtime behavior not present in code diffs.
 - Mark any uncertain inference with `[?]` and a brief reason.

--- a/.coderabbit/prompts/pr-impact-analysis.txt
+++ b/.coderabbit/prompts/pr-impact-analysis.txt
@@ -7,7 +7,7 @@ When invoked on a pull request (PR), do the following:
 3) For each affected module, estimate the **risk** as Low / Medium / High and explain why (use: file churn, header changes, public API changes, changes in include headers, build flags).
 4) Produce a short **test checklist** (concrete tests to run locally in Yocto/devshell or unit tests).
 5) Detect likely **feature impacts** (user-facing endpoints, APIs, or behavior) and map them to file paths.
-6) If public headers (`modules/**/include/**/*.h` or `modules/**/include/**/*.hpp`) are changed, explicitly call out potential API breakage and recommend adding/patching `CHANGELOG.md` with the suggested changelog bullet.
+6) If any headers (`modules/**/include/**/*.h` or `modules/**/include/**/*.hpp`) are changed, explicitly call out potential API breakage and recommend adding/patching `CHANGELOG.md` with the suggested changelog bullet.
 7) Provide an **actionable suggestion** (one-sentence) to reduce risk (e.g., "add unit tests for X", "pin dependency Y", "write integration test for module Z").
 8) Keep output compact (max 12 bullet points). Use code references (filename:line if available).
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .*
 !.gitignore
 !.coderabbit.yaml
+!.coderabbit/
 
 *.autosave
 *.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # ignore dot files/directories
 .*
 !.gitignore
+!.coderabbit.yaml
 
 *.autosave
 *.pyc

--- a/3rdparty/libjasper/jp2_cod.c
+++ b/3rdparty/libjasper/jp2_cod.c
@@ -935,6 +935,25 @@ static int jp2_uuid_putdata(jp2_box_t *box, jas_stream_t *out)
     return 0;
 }
 
+static int jp2_uuid_putdata_ab(jp2_box_t *box, jas_stream_t *out)
+{
+    jp2_uuid_t *uuid = &box->data.uuid;
+    int i;
+
+    for (i = 0; i < 13; i++)
+    {
+        if (jp2_putuint8(out, uuid->uuid[i]))
+        return -1;
+    }
+
+    for (i = 0; i < uuid->datalen; i++)
+    {
+        if (jp2_putuint8(out, uuid->data[i]))
+        return -1;
+    }
+    return 0;
+}
+
 static int jp2_getint(jas_stream_t *in, int s, int n, int_fast32_t *val)
 {
     int c;

--- a/3rdparty/libjasper/jp2_cod.c
+++ b/3rdparty/libjasper/jp2_cod.c
@@ -135,7 +135,7 @@ static void jp2_pclr_dumpdata(jp2_box_t *box, FILE *out);
 static void jp2_uuid_destroy(jp2_box_t *box);
 static int jp2_uuid_getdata(jp2_box_t *box, jas_stream_t *in);
 static int jp2_uuid_putdata(jp2_box_t *box, jas_stream_t *out);
-static int jp2_uuid_putdata_ab(jp2_box_t *box, jas_stream_t *out);
+
 
 /******************************************************************************\
 * Local data.

--- a/3rdparty/libjasper/jp2_cod.c
+++ b/3rdparty/libjasper/jp2_cod.c
@@ -135,6 +135,7 @@ static void jp2_pclr_dumpdata(jp2_box_t *box, FILE *out);
 static void jp2_uuid_destroy(jp2_box_t *box);
 static int jp2_uuid_getdata(jp2_box_t *box, jas_stream_t *in);
 static int jp2_uuid_putdata(jp2_box_t *box, jas_stream_t *out);
+static int jp2_uuid_putdata_ab(jp2_box_t *box, jas_stream_t *out);
 
 /******************************************************************************\
 * Local data.

--- a/3rdparty/libjasper/jp2_cod.h
+++ b/3rdparty/libjasper/jp2_cod.h
@@ -300,6 +300,7 @@ jp2_box_t *jp2_box_create(int type);
 void jp2_box_destroy(jp2_box_t *box);
 jp2_box_t *jp2_box_get(jas_stream_t *in);
 int jp2_box_put(jp2_box_t *box, jas_stream_t *out);
+static int jp2_uuid_putdata_ab(jp2_box_t *box, jas_stream_t *out);
 
 #define JP2_DTYPETOBPC(dtype) \
   ((JAS_IMAGE_CDT_GETSGND(dtype) << 7) | (JAS_IMAGE_CDT_GETPREC(dtype) - 1))


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated PR impact analysis with concise summaries, per-module risk assessments, test checklists, PR comment templates, and an agent prompt to drive these analyses.

* **Chores**
  * Added quality gates (docstring coverage, PR size, complexity) and enabled static analysis tooling.
  * Added custom checks (TODO/FIXME detection, changelog enforcement for public API changes, API-change signaling) and label/comment actions.
  * Began tracking reviewer/configuration files (.coderabbit) in version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->