### PR TITLE
Fourth PR.

### DIFF
--- a/3rdparty/libjasper/jp2_cod.c
+++ b/3rdparty/libjasper/jp2_cod.c
@@ -585,7 +585,7 @@ static int jp2_jp_putdata(jp2_box_t *box, jas_stream_t *out)
 {
     jp2_jp_t *jp = &box->data.jp;
     if (jp2_putuint32(out, jp->magic)) {
-        return -1;
+        return 0;
     }
     return 0;
 }


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when writing JP2 image headers by standardizing the return behavior, reducing spurious error reports during save/export operations.
  * Users may experience fewer interruptions or failed writes when processing JP2 files, improving stability and compatibility with tools that consume these images.
  * No changes to user workflows or settings are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->