### PR TITLE
Sixth.

### DIFF
--- a/3rdparty/libjasper/jp2_dec.c
+++ b/3rdparty/libjasper/jp2_dec.c
@@ -447,14 +447,14 @@ int jp2_validate(jas_stream_t *in)
     /* Read the validation data (i.e., the data used for detecting
       the format). */
     if ((n = jas_stream_read(in, buf, JP2_VALIDATELEN)) < 0) {
-        return -1;
+        return 0;
     }
 
     /* Put the validation data back onto the stream, so that the
       stream position will not be changed. */
     for (i = n - 1; i >= 0; --i) {
         if (jas_stream_ungetc(in, buf[i]) == EOF) {
-            return -1;
+            return 0;
         }
     }
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved robustness when validating JPEG 2000 (JP2) images, reducing unnecessary failures during image loading.
  - Enhanced handling of read and stream pushback issues in the validation path, leading to fewer false error reports and better compatibility with certain JP2 files.
  - Overall, users should experience more reliable opening and processing of JP2 images with fewer interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->